### PR TITLE
Adding PIP package exports

### DIFF
--- a/hplib/__init__.py
+++ b/hplib/__init__.py
@@ -2,3 +2,5 @@
 
 from . import _version
 __version__ = _version.get_versions()['version']
+
+from .hplib import *


### PR DESCRIPTION
PIP package is missing exports. Code examples fails with errors like:
```
 AttributeError: module 'hplib' has no attribute 'load_database'
```